### PR TITLE
added extra smart-tv check

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -48,7 +48,7 @@ function DeviceParser(user_agent, options) {
             ua = 'FlipboardProxy/1.1;  http://flipboard.com/browserproxy';
         if (ua.match(/Applebot/i))
             ua = 'Applebot/0.1;  http://www.apple.com/go/applebot';
-        if (ua.match(/GoogleTV|SmartTV|Internet TV|NetCast|NETTV|AppleTV|boxee|Kylo|Roku|DLNADOC|hbbtv|CrKey|CE\-HTML/i)) {
+        if (ua.match(/GoogleTV|SmartTV|SMART-TV|Internet TV|NetCast|NETTV|AppleTV|boxee|Kylo|Roku|DLNADOC|hbbtv|CrKey|CE\-HTML/i)) {
             // if user agent is a smart TV - http://goo.gl/FocDk
             return 'tv';
         } else if (ua.match(/Xbox|PLAYSTATION (3|4)|Wii/i)) {


### PR DESCRIPTION
My samsung smart tv has user agent 
`Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1`
And was not recognised.
