### PR TITLE
Add moatbot detection

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -81,7 +81,7 @@ function DeviceParser(user_agent, options) {
         } else if ((ua.match(/Windows (NT|XP|ME|9)/) && !ua.match(/Phone/i)) && !ua.match(/Bot|Spider|ia_archiver|NewsGator/i) || ua.match(/Win( ?9|NT)/i)) {
             // if user agent is Windows Desktop
             return 'desktop';
-        } else if (ua.match(/Macintosh|PowerPC/i) && !ua.match(/Silk/i)) {
+        } else if (ua.match(/Macintosh|PowerPC/i) && !ua.match(/Silk|moatbot/i)) {
             // if agent is Mac Desktop
             return 'desktop';
         } else if (ua.match(/Linux/i) && ua.match(/X11/i) && !ua.match(/Charlotte|JobBot/i)) {

--- a/test/device_bot_desktop_test.js
+++ b/test/device_bot_desktop_test.js
@@ -2433,4 +2433,10 @@ describe('device', function() {
             assert.equal(mydevice.is('bot'), true);
         });
     });
+    describe('moatbot', function () {
+        it('should get true', function() {
+            var mydevice = device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36 moatbot');
+            assert.equal(mydevice.is('bot'), true);
+        });
+    })
 });


### PR DESCRIPTION
We observed that 
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36 moatbot`
was being classified as desktop. This is an update that classifies it as a bot.
