### PR TITLE
Allow iPhone to be classed as a 'phone'

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -104,6 +104,9 @@ function DeviceParser(user_agent, options) {
         } else if (ua.match(/Mozilla\/5\.0 \(\)|jack|Applebot|FlipboardProxy|Go 1.1 package|HTMLParser|simplereach|python-requests|ShowyouBot|MetaURI|nineconnections|(^Java\/[0-9._]*)|Commons-HttpClient|InAGist|HTTP-Java-Client|curl|Wget|Bot|B-O-T|Crawler|Spider|Spyder|Yahoo|ia_archiver|Covario-IDS|findlinks|DataparkSearch|larbin|Mediapartners-Google|NG-Search|Snappy|Teoma|Jeeves|Charlotte|NewsGator|TinEye|Cerberian|SearchSight|Zao|Scrubby|Qseero|PycURL|Pompos|oegp|SBIder|yoogliFetchAgent|yacy|webcollage|VYU2|voyager|updated|truwoGPS|StackRambler|Sqworm|silk|semanticdiscovery|ScoutJet|Nymesis|NetResearchServer|MVAClient|mogimogi|Mnogosearch|Arachmo|Accoona|holmes|htdig|ichiro|webis|LinkWalker|lwp-trivial|facebookexternalhit|monit\/|ELB-HealthChecker\/|JobBot|GoogleCloudMonitoring|GoogleStackdriverMonitoring|gomezagent|apm synthetic agent|ruxitsynthetic|ktxn|khte|ktht|dynatrace|TrendsmapResolver|WinHTTP/i) && !ua.match(/phone|Playstation/i)) {
             // if user agent is a BOT/Crawler/Spider
             return self.options.botUserAgentDeviceType;
+        } else if (ua.match(/iPhone/i)) {
+            // before considering this user agent as unknown, accept iPhone is a phone
+            return 'phone';
         } else {
             // Otherwise returning the unknown type configured
             return self.options.unknownUserAgentDeviceType;

--- a/test/device_phone_6_test.js
+++ b/test/device_phone_6_test.js
@@ -1780,7 +1780,7 @@ describe('device', function() {
     });
     describe('10297.iPhone (issue #31)',function(){
         it('should get device type phone', function(){
-            var mydevice = device('Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Snapchat/10.47.5.13 (iPhone10,1; iOS 12.1.2; gzip)');
+            var mydevice = device('Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Snapchat/10.47.5.13 (iPhone10,1; iOS 12.1.2; gzip)', {unknownUserAgentDeviceType: null});
             assert.equal(mydevice.type, 'phone');
         });
     });


### PR DESCRIPTION
Some iPhone user agent strings are not matching to 'phone' - as raised in #31.

This PR:

* adds config to the test case in commit 85d92c941f6b7d7ae5f2dcb3a11f2ac66434a5a4 to avoid the default fallback to 'phone'. The test then fails.

* adds a condition after all other attempts to match, to match a user agent string including `iPhone` as `'phone'`.  The test passes.

______
The following is how I can now receive `'phone'` for `iPhone`, whilst still receiving `null` for other unknown strings.

```
device(
  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)', 
  {unknownUserAgentDeviceType: null}
).type

// 'phone'
```